### PR TITLE
fix: 优化移动端屏幕适配

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -184,7 +184,7 @@ const AppContainer = () => {
   };
   
   return (
-    <div className="h-screen w-screen flex bg-[var(--bg-image)] text-[var(--text-color)] overflow-hidden">
+    <div className="h-dvh-screen w-screen flex bg-[var(--bg-image)] text-[var(--text-color)] overflow-hidden">
         <ToastContainer />
         {isMobileSidebarOpen && <div className="fixed inset-0 bg-black/30 z-30 md:hidden" onClick={() => setIsMobileSidebarOpen(false)} aria-hidden="true"/>}
         <Sidebar chats={chats} folders={folders} activeChatId={activeChatId} onNewChat={() => handleNewChat(null)} onSelectChat={handleSelectChat} onDeleteChat={chatDataHandlers.handleDeleteChat} onEditChat={setEditingChat} onArchiveChat={(id) => chatDataHandlers.handleArchiveChat(id, true)} onNewFolder={() => setEditingFolder('new')} onEditFolder={setEditingFolder} onDeleteFolder={chatDataHandlers.handleDeleteFolder} onMoveChatToFolder={chatDataHandlers.handleMoveChatToFolder} isCollapsed={isSidebarCollapsed} onToggleCollapse={() => setIsSidebarCollapsed(p => !p)} isMobileSidebarOpen={isMobileSidebarOpen} onToggleMobileSidebar={() => setIsMobileSidebarOpen(false)} searchQuery={searchQuery} onSetSearchQuery={setSearchQuery} onOpenSettings={() => setIsSettingsOpen(true)} onOpenPersonas={handleOpenPersonas} onOpenArchive={handleOpenArchive} onOpenTranslate={handleOpenTranslate} />

--- a/index.css
+++ b/index.css
@@ -56,6 +56,10 @@ body {
     -moz-osx-font-smoothing: grayscale;
 }
 
+.h-dvh-screen {
+    height: 100dvh;
+}
+
 body.dark-mode {
     --bg-color: var(--bg-color-dark);
     --bg-image: var(--bg-image-dark);


### PR DESCRIPTION
使用 100dvh 替代 100vh，以解决移动端浏览器（如 Safari）上因地址栏动态显隐导致的视口高度问题，确保应用 UI 在屏幕内完整显示。